### PR TITLE
fix font paths

### DIFF
--- a/reveal/css/theme/gdicool.css
+++ b/reveal/css/theme/gdicool.css
@@ -1,24 +1,24 @@
 @font-face {
   font-family: "Gotham";
-  src: local("Gotham"), url("fonts/Gotham/Gotham-Medium.otf") format("opentype");
+  src: local("Gotham"), url("../../lib/font/Gotham-Medium.otf") format("opentype");
   font-weight: normal;
   font-style: normal; }
 
 @font-face {
   font-family: "Gotham-Book";
-  src: local("Gotham-Book"), url("fonts/Gotham/Gotham-Book.otf") format("opentype");
+  src: local("Gotham-Book"), url("../../lib/font/Gotham-Book.otf") format("opentype");
   font-weight: normal;
   font-style: normal; }
 
 @font-face {
   font-family: "Gotham-Italic";
-  src: local("Gotham-Italic"), url("fonts/Gotham/Gotham-MediumItalic.otf") format("opentype");
+  src: local("Gotham-Italic"), url("../../lib/font/Gotham-MediumItalic.otf") format("opentype");
   font-weight: normal;
   font-style: italic; }
 
 @font-face {
   font-family: "Gotham-Bold";
-  src: local("Gotham-Bold"), url("fonts/Gotham/Gotham-Bold.otf") format("opentype");
+  src: local("Gotham-Bold"), url("../../lib/font/Gotham-Bold.otf") format("opentype");
   font-weight: bold;
   font-style: bold; }
 

--- a/reveal/css/theme/gdidefault.css
+++ b/reveal/css/theme/gdidefault.css
@@ -1,24 +1,24 @@
 @font-face {
   font-family: "Gotham";
-  src: local("Gotham"), url("fonts/Gotham/Gotham-Medium.otf") format("opentype");
+  src: local("Gotham"), url("../../lib/font/Gotham-Medium.otf") format("opentype");
   font-weight: normal;
   font-style: normal; }
 
 @font-face {
   font-family: "Gotham-Book";
-  src: local("Gotham-Book"), url("fonts/Gotham/Gotham-Book.otf") format("opentype");
+  src: local("Gotham-Book"), url("../../lib/font/Gotham-Book.otf") format("opentype");
   font-weight: normal;
   font-style: normal; }
 
 @font-face {
   font-family: "Gotham-Italic";
-  src: local("Gotham-Italic"), url("fonts/Gotham/Gotham-MediumItalic.otf") format("opentype");
+  src: local("Gotham-Italic"), url("../../lib/font/Gotham-MediumItalic.otf") format("opentype");
   font-weight: normal;
   font-style: italic; }
 
 @font-face {
   font-family: "Gotham-Bold";
-  src: local("Gotham-Bold"), url("fonts/Gotham/Gotham-Bold.otf") format("opentype");
+  src: local("Gotham-Bold"), url("../../lib/font/Gotham-Bold.otf") format("opentype");
   font-weight: bold;
   font-style: bold; }
 

--- a/reveal/css/theme/gdilight.css
+++ b/reveal/css/theme/gdilight.css
@@ -1,24 +1,24 @@
 @font-face {
   font-family: "Gotham";
-  src: local("Gotham"), url("fonts/Gotham/Gotham-Medium.otf") format("opentype");
+  src: local("Gotham"), url("../../lib/font/Gotham-Medium.otf") format("opentype");
   font-weight: normal;
   font-style: normal; }
 
 @font-face {
   font-family: "Gotham-Book";
-  src: local("Gotham-Book"), url("fonts/Gotham/Gotham-Book.otf") format("opentype");
+  src: local("Gotham-Book"), url("../../lib/font/Gotham-Book.otf") format("opentype");
   font-weight: normal;
   font-style: normal; }
 
 @font-face {
   font-family: "Gotham-Italic";
-  src: local("Gotham-Italic"), url("fonts/Gotham/Gotham-MediumItalic.otf") format("opentype");
+  src: local("Gotham-Italic"), url("../../lib/font/Gotham-MediumItalic.otf") format("opentype");
   font-weight: normal;
   font-style: italic; }
 
 @font-face {
   font-family: "Gotham-Bold";
-  src: local("Gotham-Bold"), url("fonts/Gotham/Gotham-Bold.otf") format("opentype");
+  src: local("Gotham-Bold"), url("../../lib/font/Gotham-Bold.otf") format("opentype");
   font-weight: bold;
   font-style: bold; }
 

--- a/reveal/css/theme/gdisunny.css
+++ b/reveal/css/theme/gdisunny.css
@@ -1,24 +1,24 @@
 @font-face {
   font-family: "Gotham";
-  src: local("Gotham"), url("fonts/Gotham/Gotham-Medium.otf") format("opentype");
+  src: local("Gotham"), url("../../lib/font/Gotham-Medium.otf") format("opentype");
   font-weight: normal;
   font-style: normal; }
 
 @font-face {
   font-family: "Gotham-Book";
-  src: local("Gotham-Book"), url("fonts/Gotham/Gotham-Book.otf") format("opentype");
+  src: local("Gotham-Book"), url("../../lib/font/Gotham-Book.otf") format("opentype");
   font-weight: normal;
   font-style: normal; }
 
 @font-face {
   font-family: "Gotham-Italic";
-  src: local("Gotham-Italic"), url("fonts/Gotham/Gotham-MediumItalic.otf") format("opentype");
+  src: local("Gotham-Italic"), url("../../lib/font/Gotham-MediumItalic.otf") format("opentype");
   font-weight: normal;
   font-style: italic; }
 
 @font-face {
   font-family: "Gotham-Bold";
-  src: local("Gotham-Bold"), url("fonts/Gotham/Gotham-Bold.otf") format("opentype");
+  src: local("Gotham-Bold"), url("../../lib/font/Gotham-Bold.otf") format("opentype");
   font-weight: bold;
   font-style: bold; }
 

--- a/reveal/css/theme/template/settings.scss
+++ b/reveal/css/theme/template/settings.scss
@@ -5,28 +5,28 @@
 @font-face {
 	font-family: "Gotham";
 	src: local("Gotham"),
-	url("fonts/Gotham/Gotham-Medium.otf") format("opentype");
+	url("../../lib/font/Gotham/Gotham-Medium.otf") format("opentype");
 	font-weight: normal;
 	font-style: normal;
 }
 @font-face {
 	font-family: "Gotham-Book";
 	src: local("Gotham-Book"),
-	url("fonts/Gotham/Gotham-Book.otf") format("opentype");
+	url("../../lib/font/Gotham-Book.otf") format("opentype");
 	font-weight: normal;
 	font-style: normal;
 }
 @font-face {
 	font-family: "Gotham-Italic";
 	src: local("Gotham-Italic"),
-	url("fonts/Gotham/Gotham-MediumIta.otf") format("opentype");
+	url("../../lib/font/Gotham-MediumIta.otf") format("opentype");
 	font-weight: normal;
 	font-style: italic;
 }
 @font-face {
 	font-family: "Gotham-Bold";
 	src: local("Gotham-Bold"),
-	url("fonts/Gotham/Gotham-Bold.otf") format("opentype");
+	url("../../lib/font/Gotham-Bold.otf") format("opentype");
 	font-weight: bold;
 	font-style: bold;
 }


### PR DESCRIPTION
## Changes

The CSS files for reveal have broken paths for the font files. This commit fixes them in the compiled css plus the settings file variable.
## Screenshot
### Sunny theme slide with Gotham working

![screenshot 2015-02-26 22 24 11](https://cloud.githubusercontent.com/assets/702526/6407008/43ebe482-be06-11e4-8159-b82a5cc43323.png)
